### PR TITLE
Running phishdetect-node in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.13
+
+WORKDIR /go/src/app
+COPY . .
+
+RUN apt-get update -y && apt-get install -y libyara-dev pkg-config
+
+RUN make deps
+RUN make linux
+
+ENTRYPOINT ./build/linux/phishdetect-node --host 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ In order to build PhishDetect Node you need Go 1.12+ installed. You can then pro
 
 For proper documentation please refer to the [Admin Guide](https://phishdetect.gitbook.io/admin-guide/).
 
+## Docker
+
+To build and run PhishDetect Node in a local Docker container, install Docker
+and run
+
+    docker build -t phishdetect-node .
+    docker run -it --rm --name phishdetect-container -p 7856:7856 phishdetect-node
+
+You can then access the node at `localhost:7856`.
+
 ## License
 
 PhishDetect Node is released under GNU Affero General Public License 3.0 and is copyrighted to Claudio Guarnieri.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ and run
     docker build -t phishdetect-node .
     docker run -it --rm --name phishdetect-container -p 7856:7856 phishdetect-node
 
-You can then access the node at `localhost:7856`.
+To run both PhishDetect Node and MongoDB in containers, use docker-compose:
+
+    docker-compose build
+    docker-compose up
+
+You can then access the node at `http://localhost:7856`.
 
 ## License
 

--- a/database.go
+++ b/database.go
@@ -78,8 +78,8 @@ const IndicatorsLimitAll = 0
 const IndicatorsLimit6Months = 1
 const IndicatorsLimit24Hours = 2
 
-func NewDatabase() (*Database, error) {
-	client, err := mongo.NewClient(options.Client().ApplyURI("mongodb://localhost:27017"))
+func NewDatabase(url string) (*Database, error) {
+	client, err := mongo.NewClient(options.Client().ApplyURI(url))
 	if err != nil {
 		return nil, err
 	}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: '2'
+
+services:
+  phishdetect-node:
+    build: .
+    container_name: "phishdetect-node"
+    ports:
+      - "7856:7856"
+    entrypoint:
+      - ./build/linux/phishdetect-node
+      - --host=0.0.0.0
+      - --mongo=mongodb://database:27017
+      - --debug
+
+  database:
+    image: 'mongo'
+    container_name: "phishdetect-mongo"
+    volumes:
+      - ./mongo-volume:/data/db

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ const (
 var (
 	host         string
 	portNumber   string
+	mongoURL     string
 	apiVersion   string
 	safeBrowsing string
 	brandsPath   string
@@ -70,6 +71,7 @@ var (
 func init() {
 	debug := flag.Bool("debug", false, "Enable debug logging")
 
+	flag.StringVar(&mongoURL, "mongo", "mongodb://localhost:27017", "Specify the mongodb url")
 	flag.StringVar(&host, "host", "127.0.0.1", "Specify the host to bind the service on")
 	flag.StringVar(&portNumber, "port", "7856", "Specify which port number to bind the service on")
 	flag.StringVar(&apiVersion, "api-version", "1.37", "Specify which Docker API version to use")
@@ -106,7 +108,7 @@ func init() {
 
 	// Initiate connection to database.
 	var err error
-	db, err = NewDatabase()
+	db, err = NewDatabase(mongoURL)
 	if err != nil {
 		log.Fatal("Failed connection to database: ", err.Error())
 		return


### PR DESCRIPTION
Added a Dockerfile and docker-compose.yaml for running the phishdetect-node in containerized environment! This is a really easy way to get a development server running, but perhaps it's also a useful starting point for Docker-based deployments. I wanted to use the official mongodb docker image to run mongo in its own container instead of on localhost, so I had to add a command line argument for the mongo url.